### PR TITLE
🩹 画面遷移時のログインチェックを追加、Vue.config.productionTipを実験的にtrueに

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import App from './App.vue'
 import vuetify from './plugins/vuetify'
 import router from './router'
 
-Vue.config.productionTip = false
+Vue.config.productionTip = true
 
 new Vue({
   vuetify,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -29,27 +29,32 @@ const routes = [
   {
     path: '/newSurvey',
     name: 'NewSurvey',
-    component: NewSurvey
+    component: NewSurvey,
+    meta: { requiresAuth: true }
   },
   {
     path: '/newSurvey/:id',
     name: 'NewSurvey',
-    component: NewSurvey
+    component: NewSurvey,
+    meta: { requiresAuth: true }
   },
   {
     path: '/survey/:id',
     name: 'SurveyConfirmed',
-    component: SurveyConfirmed
+    component: SurveyConfirmed,
+    meta: { requiresAuth: true }
   },
   {
     path: '/surveyAnswer',
     name: 'SurveyAnswer',
-    component: SurveyAnswer
+    component: SurveyAnswer,
+    meta: { requiresAuth: true }
   },
   {
     path: '/usersSearch',
     name: 'UsersSearch',
-    component: UsersSearch
+    component: UsersSearch,
+    meta: { requiresAuth: true }
   },
   {
     path: '/login',
@@ -64,42 +69,50 @@ const routes = [
   {
     path: '/chat',
     name: 'ChatBoard',
-    component: ChatBoard
+    component: ChatBoard,
+    meta: { requiresAuth: true }
   },
   {
     path: '/user',
     name: 'UsersList',
-    component: UsersList
+    component: UsersList,
+    meta: { requiresAuth: true }
   },
   {
     path: '/profile',
     name: 'UserProfile',
-    component: UserProfile
+    component: UserProfile,
+    meta: { requiresAuth: true }
   },
   {
     path: '/myProfile',
     name: 'MyProfile',
-    component: MyProfile
+    component: MyProfile,
+    meta: { requiresAuth: true }
   },
   {
     path: '/editProfile',
     name: 'EditProfile',
-    component: EditProfile
+    component: EditProfile,
+    meta: { requiresAuth: true }
   },
   {
     path: '/roomCreateConfirmed',
     name: 'RoomCreateConfirmed',
-    component: RoomCreateConfirmed
+    component: RoomCreateConfirmed,
+    meta: { requiresAuth: true }
   },
   {
     path: '/memberConfirmed',
     name: 'MemberConfirmed',
-    component: MemberConfirmed
+    component: MemberConfirmed,
+    meta: { requiresAuth: true }
   },
   {
     path:'/roomJoinConfirmed',
     name: 'RoomJoinConfirmed',
-    component: RoomJoinConfirmed
+    component: RoomJoinConfirmed,
+    meta: { requiresAuth: true }
   },
 ]
 


### PR DESCRIPTION
## 内容
- ログインしていなくても入れてしまう画面に、ログインチェックを追加。
- 一旦ハードコーディングしてしまっているので、後々要リファクタリング材料

## レビュー観点

- [x] ログイン画面、新規登録画面にはログインしていなくてもアクセスできるか
- [x] 上記二つ以外の画面には、ログインしていない場合はログイン画面に遷移するか