### PR TITLE
uidがnullになってしまうエラーの解決

### DIFF
--- a/src/components/layouts/DefaultSidebar.vue
+++ b/src/components/layouts/DefaultSidebar.vue
@@ -61,7 +61,7 @@ import firebase from "@/firebase/firebase"
 
 export default {
 	async mounted() {
-		this.auth = JSON.parse(sessionStorage.getItem('user'))// JSONからオブジェクトに変換
+    const currentUserId = firebase.auth().currentUser.uid
 		//collection("users")から、ログインユーザーと同じIDを検索する処理
 		const userRef = firebase.firestore().collection("users")
 		const snapshot = await userRef.get()
@@ -69,7 +69,7 @@ export default {
 			let data = {
 				id: doc.id
 			}
-			if (this.auth.uid == data.id) {
+			if (currentUserId === data.id) {
 				this.user = data
 			} else {
 				//消したらエラーになるかも？

--- a/src/views/ChatBoard.vue
+++ b/src/views/ChatBoard.vue
@@ -92,7 +92,7 @@ import DefaultSidebar from '@/components/layouts/DefaultSidebar'
 			})
 		},
 		mounted () {
-			this.auth = JSON.parse(sessionStorage.getItem('user'))
+			this.auth = firebase.auth().currentUser
 			console.log("auth call", this.auth);
 		},
 		data: () => ({
@@ -116,7 +116,7 @@ import DefaultSidebar from '@/components/layouts/DefaultSidebar'
 				return false;
 			},
 			roomId () {
-			return 	this.$route.query.room_id; 
+			return 	this.$route.query.room_id;
 			},
 		},
 		methods: {

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -109,8 +109,6 @@ methods: {
 						uid: result.user.uid,
 						password: this.password
 					}
-					//sessionStorageに保存する値は、文字列にする必要があるので、JSON.stringifyで指定
-					sessionStorage.setItem('user', JSON.stringify(auth))
 					this.$router.push('/')
 				})
 				.catch((error) => {
@@ -136,7 +134,7 @@ methods: {
 	display: inline-block;
 }
 .login-btn {
-	margin-left: 20px; 
+	margin-left: 20px;
 }
 .success-message {
 	margin-top: 20px;

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -158,10 +158,10 @@
 				</v-col>
 				<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
 				<!-- <router-link :to="{ path:`/survey/${ this.schedulesIdData }`}"> -->
-					<v-btn 
+					<v-btn
 						@click="onClick"
 						class="ma-2"
-						color="primary" 
+						color="primary"
 						dark>
 						確認
 					</v-btn>
@@ -217,7 +217,7 @@ export default {
 		firebaseのsetとaddの違い
 		テンプレート構文orテンプレートリテラル
 		*/
-	
+
 	},
 	data: () => ({
 		remarks: '',

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -115,8 +115,6 @@ methods: {
 					uid: result.user.uid,
 					password: this.password
 				}
-				//sessionStorageに保存する値は、文字列にする必要があるので、JSON.stringifyで指定
-				sessionStorage.setItem('user', JSON.stringify(auth))
 				this.$router.push('/')
 				})
 			})
@@ -143,7 +141,7 @@ methods: {
 	display: inline-block;
 }
 .login-btn {
-	margin-left: 20px; 
+	margin-left: 20px;
 }
 .error-message {
 	margin-top: 20px;

--- a/src/views/UsersList.vue
+++ b/src/views/UsersList.vue
@@ -23,14 +23,14 @@
 			<v-col
 			v-for="friend in friends"
 			:key="friend.id"
-			cols="4"> 
+			cols="4">
 			<!--this.friendsがpushした後にどういうデータが入っているか？
 				[{id: doc.id},{id: doc.id}]-->
-			
+
 			<router-link :to="{ path: '/profile', query: { friend_id: friend.id }}">
 				<v-avatar class="mb-4" color="grey darken-1" size="64"></v-avatar>
 			</router-link>
-			
+
 			</v-col>
 		</v-row>
 		</v-container>
@@ -48,7 +48,6 @@ export default {
 	},
 	mounted() {
 		this.getUserId()
-		this.auth = JSON.parse(sessionStorage.getItem('user'))// JSONからオブジェクトに変換
 	},
 	data: () => ({
 		user:'',
@@ -58,12 +57,13 @@ export default {
 		async getUserId() {
 			const userRef = firebase.firestore().collection("users")
 			const snapshot = await userRef.get()
+      const currentUserId = firebase.auth().currentUser.uid
 
 			snapshot.forEach(doc => {
 				let data = {
 					id: doc.id
 				}
-				if(data.id == this.auth.uid) {
+				if(currentUserId === data.id) {
 					this.user = data
 				}
 				//this.friendsがpushした後にどういうデータが入っているか？
@@ -89,7 +89,7 @@ export default {
 			// arr.forEach((element, index) => {
 			// obj['key' + index] = element;
 			// });
-			// 
+			//
 			// console.log(obj);
 			// const friendDoc =firebase.firestore().collection("users").doc(this.friends)
 			// console.log("friendDoc", friendDoc)

--- a/src/views/roomList.vue
+++ b/src/views/roomList.vue
@@ -24,7 +24,7 @@
 			>
 			<!--this.roomsがpushした後にどういうデータが入っているか？
 				[{id: doc.id},{id: doc.id}]-->
-				
+
 			<!--ここで/chatのパスのqueryとして、idを設定している
 			↓pathとqueryで、room_idを取得してきてる。（ここがChatBoard.vueの$routerと紐づいてる)
 			-->
@@ -32,7 +32,7 @@
 				<v-avatar class="mb-4" color="grey darken-1" size="64"></v-avatar>
 			</router-link>
 			<div>グループ1</div>
-			
+
 			</v-col>
 		</v-row>
 		</v-container>
@@ -51,15 +51,14 @@ export default {
 	async mounted() {
 		this.getRooms()
 
-	// JSON.parseでJSONからオブジェクトに変換
-	this.auth = JSON.parse(sessionStorage.getItem('user'))
+	const currentUserId = firebase.auth().currentUser.uid
 	const userRef = firebase.firestore().collection("users")
 		const snapshot = await userRef.get()
 		snapshot.forEach(doc => {
 			let data = {
 				id: doc.id
 			}
-			if(this.auth.uid === data.id) {
+			if(currentUserId === data.id) {
 				this.user = data
 			}else{
 				// console.log("success")


### PR DESCRIPTION
## 内容

- 下記エラーの解決
![image](https://user-images.githubusercontent.com/59118646/211154304-f1a6d281-f120-4fda-89d7-2298040ba6f2.png)

**原因**: ユーザー情報はsessionStorageでセットされていたがトップページではsessionをセットしていなかったのでsessionが切れたタイミング（リンクから直接遷移した場合等）でsessionStorageが空になってしまっていたためエラーが起きていたと推測する。

**解決法**: Firebaseにはユーザー情報を取得できる関数が用意されているため、sessionStorageを削除し、Firebaseのものを使用するように変更

## レビュー観点
- 上記エラーが出ないかどうか