### PR TITLE
【Feature/survey creation answer】アンケート回答者の画面実装

### DIFF
--- a/src/views/ChatBoard.vue
+++ b/src/views/ChatBoard.vue
@@ -32,7 +32,7 @@
 						<v-list-item-subtitle 
 						v-if="data.questionnairesId"
 						class="message">
-						<router-link to="/surveyAnswer">
+						<router-link :to="{ path: '/surveyAnswer', query: { room_id: roomId }}">
 							{{ data.message }}
 						</router-link>
 						</v-list-item-subtitle>
@@ -87,32 +87,24 @@ import DefaultSidebar from '@/components/layouts/DefaultSidebar'
 			DefaultSidebar
 		},
 		async created() {
+			//[roomのデータを取得]
 			const roomRef = firebase.firestore().collection("rooms").doc(this.roomId)
 			const roomDoc = await roomRef.get()
 			const room = roomDoc.data()
-			console.log("room", room);
 
+			//[questionnairesIdを取得]
 			const questionnairesIdRef = firebase.firestore().collection("questionnaires").doc(room.questionnairesId)
 			const questionnairesGet = await questionnairesIdRef.get()
 			const questionnaires = questionnairesGet.data()
-			console.log("questionnairesData", questionnaires)
-
-			//[schedulesのデータを取得して、出力する処理はアンケート回答者画面で行う]
-			// const schedulesRef = firebase.firestore().collection("schedules").doc(questionnairesData.schedulesId)
-			// const schedulesGet = await schedulesRef.get()
-			// const schedulesData = schedulesGet.data()
-			// console.log("schedulesData", schedulesData)
 
 			//メッセージをfirestoreから取得する
 			const snapshot = await roomRef.collection("messages").orderBy("createdAt", "asc").get()
 			snapshot.forEach(doc => {
-				console.log(doc.data())
 				this.messages.push(doc.data())
 			})
 		},
 		mounted () {
 			this.auth = firebase.auth().currentUser
-			console.log("auth call", this.auth);
 		},
 		data: () => ({
 			questionnairesData: '',
@@ -153,11 +145,9 @@ import DefaultSidebar from '@/components/layouts/DefaultSidebar'
 					createdAt: firebase.firestore.Timestamp.now()
 				})
 				.then((result) => {
-					console.log('success', result);
 					this.body = ""
 				})
 				.catch((error) => {
-					console.log('fail', error);
 					alert('メッセージの送信に失敗しました')
 				})
 			}

--- a/src/views/SurveyConfirmed.vue
+++ b/src/views/SurveyConfirmed.vue
@@ -20,12 +20,7 @@
 				<tbody>
 					<tr
 					v-for="(friend, index) in friends"
-					:key="`${friend.name}_${index}`"><!--
-					:key="index">
-					↑このやり方は良くない。
-					他で、indexを使った場合、キーが０の値が複数できてしまう。
-					その場合、テンプレートリテラルを使って、表示を行う。
-					-->
+					:key="`${friend.name}_${index}`">
 						<td>{{ friend.name }}</td>
 					</tr>
 				</tbody>
@@ -267,7 +262,7 @@ export default {
 			//roomsのドキュメントIDの中にサブコレクションmessageを追加
 			//一旦、追加したフィールドにuser_idを保存。←挙動確認のために入れた適当な値
 			const roomId = firebase.firestore().collection("rooms").doc(roomRef.id)
-			const messageAdd = await roomId.collection("massages").add({
+			const messageAdd = await roomId.collection("messages").add({
 				message: this.remarkModel,
 				name: this.userData.userName,
 				questionnairesId: this.questionnairesId,

--- a/src/views/roomList.vue
+++ b/src/views/roomList.vue
@@ -22,12 +22,6 @@
 			:key="room.id"
 			cols="4"
 			>
-			<!--this.roomsがpushした後にどういうデータが入っているか？
-				[{id: doc.id},{id: doc.id}]-->
-
-			<!--ここで/chatのパスのqueryとして、idを設定している
-			↓pathとqueryで、room_idを取得してきてる。（ここがChatBoard.vueの$routerと紐づいてる)
-			-->
 			<router-link :to="{ path: '/chat', query: { room_id: room.id }}">
 				<v-avatar class="mb-4" color="grey darken-1" size="64"></v-avatar>
 			</router-link>
@@ -47,13 +41,6 @@ import firebase from "@/firebase/firebase"
 export default {
 	components: {
 		DefaultSidebar
-	},
-	async created() {
-		const questionnairesRef = firebase.firestore().collection("questionnaires")
-		const questionnairesActive = await questionnairesRef.where("active", "==", true).get()
-		console.log("questionnairesActive", questionnairesActive)
-		const questionnairesUser = await questionnairesRef.where("users_id", "array-contains", "z5OszDyVMVcuNBDeR5XvOftNKz53").get()
-		console.log("questionnairesUser", questionnairesUser)
 	},
 	async mounted() {
 		this.getRooms()


### PR DESCRIPTION
### 内容
アンケート作成後、各メンバーの画面にはアンケートの通知が来て、そこからアンケート回答者画面へと遷移する実装。
参加可否を回答すると、answerのDBには各メンバーの回答が反映される。

### 確認事項
- [x] アンケート作成後、メンバーの画面に新しいルームが作成されているか
- [x] ルーム内に、リンク付きのコメントが届いているか
- [x] アンケート回答者画面に、遷移するか
- [x] アンケート回答者画面の中身と作成されたアンケートの内容が一致しているか
- [x] アンケート回答後、answerのDBに回答結果が保存されているか（schedule_id,user_id,participationInGroup)
※注視ファイル:surveyAnswer
他ファイルは、微修正のみ。

### 🐴検討事項
- 現状、備考に入力された文字を受け取り側のリンクとして活用しているが、備考が入力されない場合、相手側には何も表示されないため、コメント通知を別途設ける必要がある。
→今考えているのは、「メッセージ送信」のタイミングで、DB上に「ゴルフのお誘いが来てます⛳️」みたいなコメントを一緒に登録する方法。もしくは本人に記入させて、記入を必須の処理にする。