### PR TITLE
【fix/survey_creation_groupname】グループ名追加のための処理

### DIFF
--- a/src/Vuex/store.js
+++ b/src/Vuex/store.js
@@ -5,6 +5,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
 	state: {
+		groupName: '',
 		friends: [],
 		price: '',
 		playTime: '',
@@ -18,6 +19,7 @@ export default new Vuex.Store({
 		remark: '',
 	},
 	getters: {
+		groupName: state => state.groupName,
 		friends: state => state.friends,
 		price: state => state.price,
 		playTime: state => state.playTime,
@@ -41,6 +43,9 @@ export default new Vuex.Store({
 	//-----------------------------------
 
 	mutations: {
+		updateGroupName(state, newGroupName) {
+			state.groupName = newGroupName
+		},
 		updateFriends(state, newFriends) {
 			state.friends = newFriends
 		},
@@ -97,6 +102,9 @@ export default new Vuex.Store({
 	//-----------------------------------
 
 	actions: {
+		updateGroupName({commit}, newGroupName) {
+			commit("updateGroupName", newGroupName)
+		},
 		updateFriends({commit}, newFriends) {
 			commit("updateFriends", newFriends)
 		},

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -9,6 +9,16 @@
 	</v-app-bar>
 	<v-main>
 		<v-col
+			cols="12"
+			md="4"
+		>
+		<v-text-field
+			v-model="groupNameModel"
+			label="グループ名"
+			required
+		></v-text-field>
+		</v-col>
+		<v-col
 		class="d-flex"
 		cols="12"
 		sm="6">
@@ -356,7 +366,14 @@ export default {
 		// 		this.$store.dispatch(updateSurvey("updateFriends", value))
 		// },
 		//-----------------------------------
-		
+		groupNameModel: {
+			get() {
+				return this.$store.getters.groupName;
+			},
+			set(value) {
+				this.$store.dispatch("updateGroupName", value)
+			}
+		},
 		friends: {
 			get() {
 				return this.$store.getters.friends;

--- a/src/views/SurveyAnswer.vue
+++ b/src/views/SurveyAnswer.vue
@@ -12,6 +12,22 @@
 			<template v-slot:default>
 				<thead>
 					<tr>
+						<th class="text-center">
+							グループ名
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+					<td>{{ questionnaireContent.groupName }}</td>
+					</tr>
+				</tbody>
+			</template>
+		</v-simple-table>
+		<v-simple-table>
+			<template v-slot:default>
+				<thead>
+					<tr>
 					<th class="text-center">
 						メンバー
 					</th>

--- a/src/views/SurveyConfirmed.vue
+++ b/src/views/SurveyConfirmed.vue
@@ -13,6 +13,22 @@
 				<thead>
 					<tr>
 						<th class="text-center">
+							グループ名
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+					<td>{{ groupNameModel }}</td>
+					</tr>
+				</tbody>
+			</template>
+		</v-simple-table>
+		<v-simple-table>
+			<template v-slot:default>
+				<thead>
+					<tr>
+						<th class="text-center">
 							メンバー
 						</th>
 					</tr>
@@ -41,7 +57,8 @@
 					</tr>
 				</tbody>
 			</template>
-		</v-simple-table><v-simple-table>
+		</v-simple-table>
+		<v-simple-table>
 			<template v-slot:default>
 				<thead>
 					<tr>
@@ -255,15 +272,13 @@ export default {
 			//フィールドの値も追加
 			const roomRef = await firebase.firestore().collection("rooms").add({
 				user_id: this.user_id,
-				name: this.userData.userName,
 				questionnairesId: this.questionnairesId,
 			})
 
 			//roomsのドキュメントIDの中にサブコレクションmessageを追加
-			//一旦、追加したフィールドにuser_idを保存。←挙動確認のために入れた適当な値
 			const roomId = firebase.firestore().collection("rooms").doc(roomRef.id)
 			const messageAdd = await roomId.collection("messages").add({
-				message: this.remarkModel,
+				message: this.groupNameModel,
 				name: this.userData.userName,
 				questionnairesId: this.questionnairesId,
 				//後から、photoURLは追加すると思うから、一旦残し
@@ -273,6 +288,7 @@ export default {
 
 			const schedulesRef = firebase.firestore().collection("schedules")
 				await schedulesRef.add({
+				groupName: this.groupNameModel,
 				questionnairesId: this.questionnairesId,
 				member: JSON.stringify(this.friendsIdArray),
 				price: this.priceModel,
@@ -289,6 +305,14 @@ export default {
 		},
 	},
 	computed: {
+		groupNameModel: {
+			get() {
+				return this.$store.getters.groupName;
+			},
+			set(value) {
+				this.$store.dispatch("updateGroupName", value)
+			}
+		},
 		friends: {
 			get() {
 				return this.$store.getters.friends;


### PR DESCRIPTION
### 内容
グループ名を追加し、それをアンケート通知画面にリンクとして表示する処理実装。
### 確認事項
- [x] アンケート作成画面(newSurvey)のグループ名に記入が可能か
- [x] アンケート確認画面(surveyComfirmed)で、グループ名が表示されているか
- [x] グループ名がメンバー側の画面（chatBoard)でリンクとして表示されているか
- [x] アンケート回答画面(surveyAnswer)にて、グループ名が表示されているか