### PR TITLE
✨ アンケート作成画面のバリデーションを追加

### DIFF
--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -377,10 +377,10 @@ export default {
 		confirmationValid: false,
 		groupNameRules: [
 			v => !!v || 'グループ名は必須です',
-			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
+			v => v?.length <= 30 || 'グループ名は30文字以内で入力してください',
 		],
 		remarkNameRules: [
-			v => v.length <= 1000 || '備考は1000文字以内で入力してください',
+			v => v?.length <= 1000 || '備考は1000文字以内で入力してください',
 		],
 	}),
 	computed: {

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -8,7 +8,7 @@
 	<div style="padding: 0.5%">
 		<v-form
 			ref="form"
-			v-model="valid"
+			v-model="confirmationValid"
 			lazy-validation
 		>
 			<v-col
@@ -207,10 +207,10 @@
 					<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
 					<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
 						<v-btn 
-							:disabled="!valid"
+							:disabled="!confirmationValid"
 							color="primary"
 							class="mr-4"
-							@click="validate"
+							@click="confirmationValidate"
 						>
 							確認
 						</v-btn>
@@ -369,7 +369,7 @@ export default {
 			'鹿児島',
 			'沖縄',
 		],
-		valid: true,
+		confirmationValid: true,
 		groupNameRules: [
 			v => !!v || 'グループ名は必須です',
 			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
@@ -488,8 +488,8 @@ export default {
 		},
 	},
 	methods: {
-		validate () {
-        this.$refs.form.validate()
+		confirmationValidate () {
+        this.$refs.form.confirmationValidate()
 		},
 	},
 }

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -17,7 +17,7 @@
 			label="グループ名"
 			required
 		></v-text-field>
-		<p v-if="!groupIsValid" class="errer message">グループ名を入力してください</p>
+		<label v-if="!groupIsValid" class="error-message">グループ名を入力してください</label>
 		</v-col>
 		<v-col
 		class="d-flex"
@@ -471,3 +471,8 @@ export default {
 }
 </script>
 
+<style scoped>
+	.error-message {
+		color: brown;
+	}
+</style>

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -204,17 +204,21 @@
 							required
 						></v-text-field>
 					</v-col>
-					<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
-					<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
-						<v-btn 
-							:disabled="!confirmationValid"
-							color="primary"
-							class="mr-4"
-							@click="confirmationValidate"
-						>
-							確認
-						</v-btn>
-					</router-link>
+					<v-btn 
+						color="secondary" 
+						:to="{ path:'/', query: {user_id: this.user_id}}"
+					>
+						一覧に戻る
+					</v-btn>
+					<v-btn 
+						color="primary"
+						class="mr-4"
+						@click="confirmationValidate"
+						:disabled="confirmationValid"
+					>
+						確認
+					</v-btn>
+
 				</v-col>
 			</v-row>
 		</v-form>
@@ -475,10 +479,14 @@ export default {
 				this.$store.dispatch("updateRemark", value)
 			}
 		},
+		isValid() {
+			console.log("confirmationValid", this.confirmationValid);
+			return this.confirmationValid;
+		}
 	},
 	methods: {
 		confirmationValidate () {
-        this.$refs.form.confirmationValidate()
+			if (this.isValid) this.$router.push({ path: '/survey', query: { user_id: this.user_id }})
 		},
 	},
 }

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -15,33 +15,33 @@
 				cols="12"
 				md="4"
 			>
-			<v-text-field
-				v-model="groupNameModel"
-				label="グループ名"
-				:rules="groupNameRules"
-				:counter="30"
-				clearable
-				required
-			></v-text-field>
+				<v-text-field
+					v-model="groupNameModel"
+					label="グループ名"
+					:rules="groupNameRules"
+					:counter="30"
+					clearable
+					required
+				></v-text-field>
 			</v-col>
 			<v-col
 			class="d-flex"
 			cols="12"
 			sm="6">
-			<v-autocomplete
-				item-text="name"
-				:items="friendNameList"
-				v-model="friends"
-				outlined
-				deletable-chips
-				dense
-				chips
-				small-chips
-				label="友人検索"
-				return-object
-				multiple
-			>
-			</v-autocomplete>
+				<v-autocomplete
+					item-text="name"
+					:items="friendNameList"
+					v-model="friends"
+					outlined
+					deletable-chips
+					dense
+					chips
+					small-chips
+					label="友人検索"
+					return-object
+					multiple
+				>
+				</v-autocomplete>
 			</v-col>
 
 			<v-row>
@@ -107,23 +107,23 @@
 							offset-y
 							min-width="auto"
 						>
-						<template v-slot:activator="{ on, attrs }">
-						<v-text-field
-							v-model="date"
-							prepend-icon="mdi-calendar"
-							readonly
-							v-bind="attrs"
-							v-on="on"
-							label="候補日"
-							required
-						></v-text-field>
-						</template>
-						<v-date-picker
-							v-model="date"
-							@input="menu = false"
-							locale="jp-ja"
-							:day-format="date => new Date(date).getDate()">
-						</v-date-picker>
+							<template v-slot:activator="{ on, attrs }">
+								<v-text-field
+									v-model="date"
+									prepend-icon="mdi-calendar"
+									readonly
+									v-bind="attrs"
+									v-on="on"
+									label="候補日"
+									required
+								></v-text-field>
+							</template>
+							<v-date-picker
+								v-model="date"
+								@input="menu = false"
+								locale="jp-ja"
+								:day-format="date => new Date(date).getDate()">
+							</v-date-picker>
 						</v-menu>
 					</v-col>
 
@@ -185,23 +185,24 @@
 						cols="12"
 						md="4"
 					>
-					<v-checkbox
-						v-model="lunchModel"
-						label="昼付き"
-					></v-checkbox>
+						<v-checkbox
+							v-model="lunchModel"
+							label="昼付き"
+						></v-checkbox>
 					</v-col>
 
 					<v-col
 						cols="12"
 						md="4"
 					>
-					<v-text-field
-						v-model="remarkModel"
-						label="備考"
-						:counter="1000"
-						clearable
-						required
-					></v-text-field>
+						<v-text-field
+							v-model="remarkModel"
+							label="備考"
+							:counter="1000"
+							:rules="remarkNameRules"
+							clearable
+							required
+						></v-text-field>
 					</v-col>
 					<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
 					<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
@@ -368,11 +369,15 @@ export default {
 			'鹿児島',
 			'沖縄',
 		],
+		valid: true,
 		groupNameRules: [
 			v => !!v || 'グループ名は必須です',
 			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
 		],
-		valid: true,
+		remarkNameRules: [
+			v => !!v || 'グループ名は必須です',
+			v => v.length <= 1000 || '備考は1000文字以内で入力してください',
+		],
 	}),
 	computed: {
 		//[ハードコード用]

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -22,7 +22,6 @@
 					:rules="groupNameRules"
 					:counter="30"
 					clearable
-					required
 				></v-text-field>
 			</v-col>
 			<v-col
@@ -116,7 +115,6 @@
 									v-bind="attrs"
 									v-on="on"
 									label="候補日"
-									required
 								></v-text-field>
 							</template>
 							<v-date-picker
@@ -149,7 +147,7 @@
 							v-bind="attrs"
 							v-on="on"
 							label="回答締切"
-							required
+				
 						></v-text-field>
 						</template>
 						<v-date-picker

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -2,209 +2,220 @@
 	<v-app id="inspire">
 	<v-app-bar
 		app
-		shrink-on-scroll
 	>
 		<v-toolbar-title>アンケート作成</v-toolbar-title>
-		<v-spacer></v-spacer>
 	</v-app-bar>
-	<v-main>
-		<v-col
-			cols="12"
-			md="4"
+	<div style="padding: 0.5%">
+		<v-form
+			ref="form"
+			v-model="valid"
+			lazy-validation
 		>
-		<v-text-field
-			v-model="groupNameModel"
-			label="グループ名"
-			required
-		></v-text-field>
-		<label v-if="!groupIsValid" class="error-message">グループ名を入力してください</label>
-		</v-col>
-		<v-col
-		class="d-flex"
-		cols="12"
-		sm="6">
-		<v-autocomplete
-			item-text="name"
-			:items="friendNameList"
-			v-model="friends"
-			outlined
-			deletable-chips
-			dense
-			chips
-			small-chips
-			label="友人検索"
-			return-object
-			multiple
-		>
-		</v-autocomplete>
-		</v-col>
-
-		<v-row>
-			<v-col cols="12">
-				<v-col
-					class="d-flex"
-					cols="12"
-					sm="6"
-				>
-				<v-select
-					v-model="priceModel"
-					:items="price"
-					label="価格"
-				>
-				</v-select>
-				</v-col>
-				<v-col
-					class="d-flex"
-					cols="12"
-					sm="6"
-				>
-				<v-select
-					v-model="playTimeModel"
-					:items="startTime"
-					label="スタート時間"
-				>
-				</v-select>
-				</v-col>
-				<v-col
-					class="d-flex"
-					cols="12"
-					sm="6"
-				>
-				<v-select
-					v-model="prefModel1"
-					:items="candidatePrefectureData1"
-					label="開催候補地1"
-				>
-				</v-select>
-				</v-col>
-				<v-col
-					class="d-flex"
-					cols="12"
-					sm="6"
-				>
-				<v-select
-					v-model="prefModel2"
-					:items="candidatePrefectureData2"
-					label="開催候補地2"
-				>
-				</v-select>
-				</v-col>
-				<v-col
-					cols="12"
-					sm="6"
-					md="4"
-				>
-					<v-menu
-						v-model="menu"
-						:close-on-content-click="false"
-						:nudge-right="40"
-						transition="scale-transition"
-						offset-y
-						min-width="auto"
-					>
-					<template v-slot:activator="{ on, attrs }">
-					<v-text-field
-						v-model="date"
-						prepend-icon="mdi-calendar"
-						readonly
-						v-bind="attrs"
-						v-on="on"
-						label="候補日"
-						required
-					></v-text-field>
-					</template>
-					<v-date-picker
-						v-model="date"
-						@input="menu = false"
-						locale="jp-ja"
-						:day-format="date => new Date(date).getDate()">
-					</v-date-picker>
-					</v-menu>
-				</v-col>
-
-				<v-col
-					cols="12"
-					sm="6"
-					md="4"
-				>
-					<v-menu
-						v-model="menu1"
-						:close-on-content-click="false"
-						:nudge-right="40"
-						transition="scale-transition"
-						offset-y
-						min-width="auto"
-					>
-					<template v-slot:activator="{ on, attrs }">
-					<v-text-field
-						v-model="deadLineDate"
-						prepend-icon="mdi-calendar"
-						readonly
-						v-bind="attrs"
-						v-on="on"
-						label="回答締切"
-						required
-					></v-text-field>
-					</template>
-					<v-date-picker
-						v-model="deadLineDate"
-						@input="menu1 = false"
-						locale="jp-ja"
-						:day-format="deadLineDate => new Date(deadLineDate).getDate()">
-					</v-date-picker>
-					</v-menu>
-				</v-col>
-
-				<v-col
-					cols="12"
-					md="4"
-				>
-				<v-checkbox
-					v-model="carsModel"
-					label="車の有無"
-				></v-checkbox>
-				</v-col>
-
-				<!--次の画面から、この画面に戻ってきた時に、キャディを活性にする必要がある。-->
-				<v-col
-					cols="12"
-					md="4"
-				>
-				<v-checkbox
-					v-model="caddy"
-					label="キャディの有無"
-				></v-checkbox>
-				</v-col>
-
-				<v-col
-					cols="12"
-					md="4"
-				>
-				<v-checkbox
-					v-model="lunchModel"
-					label="昼付き"
-				></v-checkbox>
-				</v-col>
-
-				<v-col
-					cols="12"
-					md="4"
-				>
-				<v-text-field
-					v-model="remarkModel"
-					label="備考"
-					required
-				></v-text-field>
-				</v-col>
-				<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
-				<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
-					<v-btn :disabled="!groupNameModel" class="ma-2" color="primary" dark>
-						確認
-					</v-btn>
-				</router-link>
+			<v-col
+				cols="12"
+				md="4"
+			>
+			<v-text-field
+				v-model="groupNameModel"
+				label="グループ名"
+				:rules="groupNameRules"
+				:counter="30"
+				clearable
+				required
+			></v-text-field>
 			</v-col>
-		</v-row>
-	</v-main>
+			<v-col
+			class="d-flex"
+			cols="12"
+			sm="6">
+			<v-autocomplete
+				item-text="name"
+				:items="friendNameList"
+				v-model="friends"
+				outlined
+				deletable-chips
+				dense
+				chips
+				small-chips
+				label="友人検索"
+				return-object
+				multiple
+			>
+			</v-autocomplete>
+			</v-col>
+
+			<v-row>
+				<v-col cols="12">
+					<v-col
+						class="d-flex"
+						cols="12"
+						sm="6"
+					>
+					<v-select
+						v-model="priceModel"
+						:items="price"
+						label="価格"
+					>
+					</v-select>
+					</v-col>
+					<v-col
+						class="d-flex"
+						cols="12"
+						sm="6"
+					>
+					<v-select
+						v-model="playTimeModel"
+						:items="startTime"
+						label="スタート時間"
+					>
+					</v-select>
+					</v-col>
+					<v-col
+						class="d-flex"
+						cols="12"
+						sm="6"
+					>
+					<v-select
+						v-model="prefModel1"
+						:items="candidatePrefectureData1"
+						label="開催候補地1"
+					>
+					</v-select>
+					</v-col>
+					<v-col
+						class="d-flex"
+						cols="12"
+						sm="6"
+					>
+					<v-select
+						v-model="prefModel2"
+						:items="candidatePrefectureData2"
+						label="開催候補地2"
+					>
+					</v-select>
+					</v-col>
+					<v-col
+						cols="12"
+						sm="6"
+						md="4"
+					>
+						<v-menu
+							v-model="menu"
+							:close-on-content-click="false"
+							:nudge-right="40"
+							transition="scale-transition"
+							offset-y
+							min-width="auto"
+						>
+						<template v-slot:activator="{ on, attrs }">
+						<v-text-field
+							v-model="date"
+							prepend-icon="mdi-calendar"
+							readonly
+							v-bind="attrs"
+							v-on="on"
+							label="候補日"
+							required
+						></v-text-field>
+						</template>
+						<v-date-picker
+							v-model="date"
+							@input="menu = false"
+							locale="jp-ja"
+							:day-format="date => new Date(date).getDate()">
+						</v-date-picker>
+						</v-menu>
+					</v-col>
+
+					<v-col
+						cols="12"
+						sm="6"
+						md="4"
+					>
+						<v-menu
+							v-model="menu1"
+							:close-on-content-click="false"
+							:nudge-right="40"
+							transition="scale-transition"
+							offset-y
+							min-width="auto"
+						>
+						<template v-slot:activator="{ on, attrs }">
+						<v-text-field
+							v-model="deadLineDate"
+							prepend-icon="mdi-calendar"
+							readonly
+							v-bind="attrs"
+							v-on="on"
+							label="回答締切"
+							required
+						></v-text-field>
+						</template>
+						<v-date-picker
+							v-model="deadLineDate"
+							@input="menu1 = false"
+							locale="jp-ja"
+							:day-format="deadLineDate => new Date(deadLineDate).getDate()">
+						</v-date-picker>
+						</v-menu>
+					</v-col>
+
+					<v-col
+						cols="12"
+						md="4"
+					>
+					<v-checkbox
+						v-model="carsModel"
+						label="車の有無"
+					></v-checkbox>
+					</v-col>
+
+					<!--次の画面から、この画面に戻ってきた時に、キャディを活性にする必要がある。-->
+					<v-col
+						cols="12"
+						md="4"
+					>
+					<v-checkbox
+						v-model="caddy"
+						label="キャディの有無"
+					></v-checkbox>
+					</v-col>
+
+					<v-col
+						cols="12"
+						md="4"
+					>
+					<v-checkbox
+						v-model="lunchModel"
+						label="昼付き"
+					></v-checkbox>
+					</v-col>
+
+					<v-col
+						cols="12"
+						md="4"
+					>
+					<v-text-field
+						v-model="remarkModel"
+						label="備考"
+						required
+					></v-text-field>
+					</v-col>
+					<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
+					<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
+						<v-btn 
+							:disabled="!valid"
+							color="primary"
+							class="mr-4"
+							@click="validate"
+						>
+							確認
+						</v-btn>
+					</router-link>
+				</v-col>
+			</v-row>
+		</v-form>
+	</div>
 	</v-app>
 </template>
 
@@ -354,7 +365,12 @@ export default {
 			'宮崎',
 			'鹿児島',
 			'沖縄',
-		]
+		],
+		groupNameRules: [
+			v => !!v || 'グループ名は必須です',
+			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
+		],
+		valid: true,
 	}),
 	computed: {
 		//[ハードコード用]
@@ -367,10 +383,6 @@ export default {
 		// 		this.$store.dispatch(updateSurvey("updateFriends", value))
 		// },
 		//-----------------------------------
-		groupIsValid () {
-			console.log("groupNameModel:", this.groupNameModel)
-			return this.groupNameModel != ""
-		},
 		groupNameModel: {
 			get() {
 				return this.$store.getters.groupName;
@@ -467,12 +479,11 @@ export default {
 				this.$store.dispatch("updateRemark", value)
 			}
 		},
-	}
+	},
+	methods: {
+		validate () {
+        this.$refs.form.validate()
+		},
+	},
 }
 </script>
-
-<style scoped>
-	.error-message {
-		color: brown;
-	}
-</style>

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -478,7 +478,6 @@ export default {
 			}
 		},
 		isValid() {
-			console.log("confirmationValid", this.confirmationValid);
 			return this.confirmationValid;
 		}
 	},

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -198,7 +198,7 @@
 				</v-col>
 				<v-btn color="secondary" :to="{ path:'/', query: {user_id: this.user_id}}">一覧に戻る</v-btn>
 				<router-link :to="{ path: '/survey', query: { user_id: this.user_id }}">
-					<v-btn class="ma-2" color="primary" dark>
+					<v-btn :disabled="!groupNameModel" class="ma-2" color="primary" dark>
 						確認
 					</v-btn>
 				</router-link>

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -198,6 +198,8 @@
 					<v-text-field
 						v-model="remarkModel"
 						label="備考"
+						:counter="1000"
+						clearable
 						required
 					></v-text-field>
 					</v-col>

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -202,7 +202,6 @@
 							:counter="1000"
 							:rules="remarkNameRules"
 							clearable
-							required
 						></v-text-field>
 					</v-col>
 					<v-btn
@@ -474,7 +473,7 @@ export default {
 		},
 		remarkModel: {
 			get() {
-				return this.$store.getters.remark
+				return this.$store.getters.remarkModel
 			},
 			set(value) {
 				this.$store.dispatch("updateRemark", value)

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -375,21 +375,10 @@ export default {
 			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
 		],
 		remarkNameRules: [
-			v => !!v || 'グループ名は必須です',
 			v => v.length <= 1000 || '備考は1000文字以内で入力してください',
 		],
 	}),
 	computed: {
-		//[ハードコード用]
-		//-----------------------------------
-		// friends: {
-		// 	get() {
-		// 		return this.$store.getters.friends;
-		// 	},
-		// 	set(value) {
-		// 		this.$store.dispatch(updateSurvey("updateFriends", value))
-		// },
-		//-----------------------------------
 		groupNameModel: {
 			get() {
 				return this.$store.getters.groupName;

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -10,7 +10,7 @@
 			ref="form"
 			v-model="confirmationValid"
 			lazy-validation
-      @input="updateConfirmationValid"
+			@input="updateConfirmationValid"
 		>
 			<v-col
 				cols="12"
@@ -486,9 +486,15 @@ export default {
 		confirmationValidate () {
 			if (this.isValid) this.$router.push({ path: '/survey', query: { user_id: this.user_id }})
 		},
-    updateConfirmationValid() {
-       this.confirmationValid = [this.groupNameModel].every((val) => val)
-    }
+		updateConfirmationValid() {
+			this.confirmationValid = [this.groupNameModel].every((val) => val)
+			if (
+				this.groupNameModel.length > 30
+				|| this.remarkModel.length > 1000
+				) {
+				this.confirmationValid = false
+			}
+		}
 	},
 }
 </script>

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -17,6 +17,7 @@
 			label="グループ名"
 			required
 		></v-text-field>
+		<p v-if="!groupIsValid" class="errer message">グループ名を入力してください</p>
 		</v-col>
 		<v-col
 		class="d-flex"
@@ -366,6 +367,10 @@ export default {
 		// 		this.$store.dispatch(updateSurvey("updateFriends", value))
 		// },
 		//-----------------------------------
+		groupIsValid () {
+			console.log("groupNameModel:", this.groupNameModel)
+			return this.groupNameModel != ""
+		},
 		groupNameModel: {
 			get() {
 				return this.$store.getters.groupName;

--- a/src/views/NewSurvey.vue
+++ b/src/views/NewSurvey.vue
@@ -10,6 +10,7 @@
 			ref="form"
 			v-model="confirmationValid"
 			lazy-validation
+      @input="updateConfirmationValid"
 		>
 			<v-col
 				cols="12"
@@ -204,17 +205,17 @@
 							required
 						></v-text-field>
 					</v-col>
-					<v-btn 
-						color="secondary" 
+					<v-btn
+						color="secondary"
 						:to="{ path:'/', query: {user_id: this.user_id}}"
 					>
 						一覧に戻る
 					</v-btn>
-					<v-btn 
+					<v-btn
 						color="primary"
 						class="mr-4"
 						@click="confirmationValidate"
-						:disabled="confirmationValid"
+						:disabled="!confirmationValid"
 					>
 						確認
 					</v-btn>
@@ -235,7 +236,7 @@ export default {
 		const userRef = firebase.firestore().collection("users").doc(this.user_id)
 		const userDoc = await userRef.get()
 		this.user = userDoc.data()
-		
+
 		if (userDoc.get("friends") === undefined) return
 		const friendsIdArray = JSON.parse(userDoc.get("friends"))
 		if (friendsIdArray === undefined) return
@@ -373,7 +374,7 @@ export default {
 			'鹿児島',
 			'沖縄',
 		],
-		confirmationValid: true,
+		confirmationValid: false,
 		groupNameRules: [
 			v => !!v || 'グループ名は必須です',
 			v => v.length <= 30 || 'グループ名は30文字以内で入力してください',
@@ -488,6 +489,9 @@ export default {
 		confirmationValidate () {
 			if (this.isValid) this.$router.push({ path: '/survey', query: { user_id: this.user_id }})
 		},
+    updateConfirmationValid() {
+       this.confirmationValid = [this.groupNameModel].every((val) => val)
+    }
 	},
 }
 </script>


### PR DESCRIPTION
## 内容
[issue #62 なにも入力しなくてもアンケートが作成できる問題の解決＆UI上での入力制限の追加](https://github.com/Kazuki0320/GolfApp/issues/62)

before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62760395/215254682-c7eb8651-d2da-4e72-a183-df08ae780ae4.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62760395/215254686-2df5e833-0de2-4931-b7e8-3b7e2ce5f7fa.png">

after
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62760395/215254721-1dcc8b03-1786-4eb8-aa5e-d011f9c35658.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/62760395/215254724-d8e78386-5dfe-4bd7-a411-184ed251f2ff.png">



## レビュー観点
- [x] アンケート作成画面を開いた瞬間に確認ボタンが非活性になっている
- [x] グループ名が入力されていない時、確認ボタンが非活性になっている
- [x] グループ名が30文字以内で入力された時、確認ボタンが活性にする
- [x] グループ名が31文字以上入力された時、確認ボタンが非活性になる
- [x] 備考欄が1001文字以上入力させた時、確認ボタンが非活性になる