### PR TITLE
【roomList】ログインユーザーとルームの紐付け処理

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -85,7 +85,6 @@ mounted() {
 },
 computed:	{
 	isValid() {
-		console.log("isValid", this.valid);
 		return !this.valid;
 	}
 },
@@ -112,7 +111,6 @@ methods: {
 					this.$router.push('/')
 				})
 				.catch((error) => {
-					console.log("fail", error)
 					this.errorMessage = "ユーザーのログインに失敗しました"
 				})
 		}

--- a/src/views/RoomCreateConfirmed.vue
+++ b/src/views/RoomCreateConfirmed.vue
@@ -191,7 +191,7 @@ export default {
 		this.user = userDoc.data()
 		console.log("user", this.user);
 
-		this.friendsIdArray =JSON.parse(userDoc.get("friends"))
+		// this.friendsIdArray =JSON.parse(userDoc.get("friends"))
 		console.log("friendsIdArray", this.friendsIdArray)
 
 	},

--- a/src/views/SurveyAnswer.vue
+++ b/src/views/SurveyAnswer.vue
@@ -363,7 +363,7 @@
 				class="flex-grow-1 flex-shrink-0"
 			>
 			<v-select
-				label="参加可能可否"
+				label="参加可否"
 				:items="attendance"
 				item-text="text"
 				v-model="attendanceAnswerModel">
@@ -420,15 +420,17 @@ export default {
 		//[queryで、room_idを受け取ってきて、roomsの中から受け取ってきたIDのデータを取得]
 		this.roomId = this.$route.query.room_id;
 		const roomRef = firebase.firestore().collection("rooms").doc(this.roomId)
-		const roomGet = await roomRef.get()
-		const roomData = roomGet.data()
+		const roomGet = await roomRef.collection("messages").get()
+		const messagesId = roomGet.docs[0]
+		const roomData = messagesId.data()
 
 		//[回答締め切りのみquestionnairesのフィールドの値としてあるため、ここでDeadlineForResponseのデータを取得]
+		//→回答締切を表示するため
 		const questionnairesData =firebase.firestore().collection("questionnaires").doc(roomData.questionnairesId)
 		const questionnairesGet =await questionnairesData.get()
 		this.questionnairesId = questionnairesGet.data()
 
-		// [schedulesの中で上記questionnairesIdと同じ値を持つ、IDを検索してきてそのデータを表示する処理]
+		// // [schedulesの中で上記questionnairesIdと同じ値を持つ、IDを検索してきてそのデータを表示する処理]
 		const schedulesRef = firebase.firestore().collection("schedules")
 		const schedulesQuestionnaireId = await schedulesRef.where("questionnairesId", "==", roomData.questionnairesId).get()
 		this.scheduleId = schedulesQuestionnaireId.docs[0]
@@ -436,9 +438,9 @@ export default {
 		const schedulesGet = await schedulesCollection.get()
 		this.questionnaireContent = schedulesGet.data()
 
-		//[memberを表示するための処理]
-		const memberArray = JSON.parse(this.questionnaireContent.member)
-		memberArray.forEach(async doc => {
+		// //[memberを表示するための処理]
+		const membersArray = JSON.parse(this.questionnaireContent.members)
+		membersArray.forEach(async doc => {
 			const userRef = firebase.firestore().collection("users").doc(doc)
 			const userGet = await userRef.get()
 			const userData = userGet.data()
@@ -452,12 +454,13 @@ export default {
 		this.throughOrLunch = (this.questionnaireContent.throughOrLunch ? '昼付き' : 'スルー')
 		// //キャディの有無
 		this.AvailabilityOfCaddy = (this.questionnaireContent.AvailabilityOfCaddy ? '有' : '無')
+
 	},
 	data: () => ({
 		usersName: [],
 		AvailabilityOfCarItems: [
-			{value: true, text: "可"},
-			{value: false, text: "不可"},
+			{value: true, text: "○"},
+			{value: false, text: "×"},
 		],
 		attendance: [
 			{value: 'yes', text: "○"},

--- a/src/views/SurveyAnswerConfirmed.vue
+++ b/src/views/SurveyAnswerConfirmed.vue
@@ -366,7 +366,7 @@
 					outlined
 					tile
 				>
-				参加可能可否
+				参加可否
 				</v-card>
 			</v-col>
 			<v-col
@@ -485,8 +485,9 @@ export default {
 		//[queryで、room_idを受け取ってきて、roomsの中から受け取ってきたIDのデータを取得]
 		this.roomId = this.$route.query.room_id;
 		const roomRef = firebase.firestore().collection("rooms").doc(this.roomId)
-		const roomGet = await roomRef.get()
-		const roomData = roomGet.data()
+		const roomGet = await roomRef.collection("messages").get()
+		const messagesId = roomGet.docs[0]
+		const roomData = messagesId.data()
 
 		//[回答締め切りのみquestionnairesのフィールドの値としてあるため、ここでDeadlineForResponseのデータを取得]
 		const questionnairesData =firebase.firestore().collection("questionnaires").doc(roomData.questionnairesId)
@@ -500,10 +501,9 @@ export default {
 		const schedulesCollection = firebase.firestore().collection("schedules").doc(this.scheduleId.id)
 		const schedulesGet = await schedulesCollection.get()
 		this.questionnaireContent = schedulesGet.data()
-		console.log("questionnaireContent", this.questionnaireContent)
 
 		//[memberを表示するための処理]
-		const memberArray = JSON.parse(this.questionnaireContent.member)
+		const memberArray = JSON.parse(this.questionnaireContent.members)
 		memberArray.forEach(async doc => {
 			const userRef = firebase.firestore().collection("users").doc(doc)
 			const userGet = await userRef.get()
@@ -519,8 +519,8 @@ export default {
 		//キャディの有無
 		this.AvailabilityOfCaddy = (this.questionnaireContent.AvailabilityOfCaddy ? '有' : '無')
 		//車出しが可能かどうかの処理
-		this.AvailabilityOfCarAnswer = (this.isCarAnswerModel ? '可' : '不可')
-		if(this.AvailabilityOfCarAnswer === '可') {
+		this.AvailabilityOfCarAnswer = (this.isCarAnswerModel ? "○" : "×")
+		if(this.AvailabilityOfCarAnswer === "○") {
 			this.carAnswer = true
 		}else {
 			this.carAnswer = false

--- a/src/views/SurveyConfirmed.vue
+++ b/src/views/SurveyConfirmed.vue
@@ -231,10 +231,13 @@ export default {
 		// //キャディの有無
 		this.AvailabilityOfCaddy = (this.caddyModel ? '有' : '無')
 
+		//状態管理から、受け取ってきたfriendsのデータのIDを取得するための処理
 		this.friends.forEach(friends => {
 			const friendId = friends.id
-			this.friendsIdArray.push(friendId)
+			this.members.push(friendId)
 		})
+		//roomのフィールドに作成者＋メンバー含めたIDを持つ配列を作成
+		this.members.push(this.user_id)
 	},
 	data: () => ({
 		userData: '',
@@ -248,7 +251,7 @@ export default {
 		room_id: '',
 		active: true,
 		answered: false,
-		friendsIdArray: [],
+		members: [],
 		rooms: [],
 	}),
 	methods: {
@@ -264,16 +267,15 @@ export default {
 					answered: this.answered,
 					room_id: this.room_id,
 					user_id: this.user_id,
-					users_id: JSON.stringify(this.friendsIdArray),
+					users_id: JSON.stringify(this.members),
 					DeadlineForResponse: this.deadLineDate,
 				})
 			this.questionnairesId = result1.id
 
 			//roomsのドキュメントIDを作成
-			//フィールドの値も追加
+			//フィールドの値には選択したユーザーのIDも含め、users_idとして追加
 			const roomRef = await firebase.firestore().collection("rooms").add({
-				user_id: this.user_id,
-				questionnairesId: this.questionnairesId,
+				members_id: this.members,
 			})
 
 			//roomsのドキュメントIDの中にサブコレクションmessageを追加
@@ -291,7 +293,7 @@ export default {
 				await schedulesRef.add({
 				groupName: this.groupNameModel,
 				questionnairesId: this.questionnairesId,
-				member: JSON.stringify(this.friendsIdArray),
+				members: JSON.stringify(this.members),
 				price: this.priceModel,
 				playTime: this.playTimeModel,
 				selectPlace1: this.candidatePrefectureModel1,

--- a/src/views/SurveyResultsAnswer.vue
+++ b/src/views/SurveyResultsAnswer.vue
@@ -98,6 +98,8 @@ import firebase from "@/firebase/firebase"
 				const answerRef = firebase.firestore().collection("answer").doc(doc)
 				const answerGet = await answerRef.get()
 				const answerData = answerGet.data()
+				this.surveyAnswer = answerData
+
 				let userData = {
 					userId:answerData.user_id
 				}
@@ -115,18 +117,20 @@ import firebase from "@/firebase/firebase"
 			const schedulesData = schedulesGet.data()
 			this.schedulesInfo.push(schedulesData)
 
-			//[schedulesInfoからquestionnairesIdとmemberのIdを取得]
+			//[schedulesInfoからquestionnairesIdとmembersのIdを取得]
 			this.schedulesInfo.forEach(async doc => {
 				this.questionnaireId = doc.questionnairesId
-				this.memberId = doc.member
+				this.membersId = doc.members
 			})
 
 			// //車の有無を表示するための処理
-			this.AvailabilityOfCar = (this.surveyResultAnswer.AvailabilityOfCar ? '有' : '無')
+			this.AvailabilityOfCar = (this.surveyAnswer.AvailabilityOfCar ? '有' : '無')
 			// 参加可否を表示するための処理
-			this.participationInGroup = (this.surveyResultAnswer.participationInGroup ? '可' : '不可')
+			this.participationInGroup = (this.surveyAnswer.participationInGroup ? '可' : '不可')
+
 			},
 		data: () => ({
+			surveyAnswer: '',
 			participationInGroup: '',
 			AvailabilityOfCar: '',
 			usersInfo: [],
@@ -139,21 +143,19 @@ import firebase from "@/firebase/firebase"
 			surveyResultAnswer: [],
 			questionnaireId: '',
 			groupName:'',
-			memberId: '',
+			membersId: [],
 		}),
 		methods: {
 			async roomMakeOnClick() {
 			//groupNameの取得処理
 			this.schedulesInfo.forEach(value => {
 				this.groupName = value.groupName
-				this.memberId = value.member
+				this.membersId = value.members
 			})
-			
+
 			//roomsのドキュメントIDを作成し、フィールドの値を追加
 			const roomRef = await firebase.firestore().collection("rooms").add({
-				user_id: this.userId,
-				member_id: this.memberId,
-				questionnairesId: this.questionnaireId,
+				members_id: this.membersId,
 			})
 
 			//roomsのドキュメントIDの中にサブコレクションmessageを追加

--- a/src/views/roomList.vue
+++ b/src/views/roomList.vue
@@ -49,10 +49,10 @@ export default {
 		const userGet = await userRef.get()
 		this.user = userGet.data()
 
-		//[ログインユーザーが作成したroomを表示する処理]
+		//[ログインユーザーが招待されているグループの探索処理]
 		const roomRef = firebase.firestore().collection("rooms")
-		const roomGet = await roomRef.where("user_id", "==", currentUserId).get()
-		roomGet.forEach(doc => {
+		const memberGet = await roomRef.where("members_id", "array-contains",  currentUserId).get()
+		memberGet.forEach(doc => {
 			let data = {
 				id: doc.id
 			}

--- a/src/views/roomList.vue
+++ b/src/views/roomList.vue
@@ -43,42 +43,28 @@ export default {
 		DefaultSidebar
 	},
 	async mounted() {
-		this.getRooms()
+		//[ルーム作成ボタンを押した際、userIdを次の遷移先へ渡すためuserデータを取得]
+		const currentUserId = firebase.auth().currentUser.uid
+		const userRef = firebase.firestore().collection("users").doc(currentUserId)
+		const userGet = await userRef.get()
+		this.user = userGet.data()
 
-	this.currentUserId = firebase.auth().currentUser.uid
-	const userRef = firebase.firestore().collection("users")
-		const snapshot = await userRef.get()
-		snapshot.forEach(doc => {
+		//[ログインユーザーが作成したroomを表示する処理]
+		const roomRef = firebase.firestore().collection("rooms")
+		const roomGet = await roomRef.where("user_id", "==", currentUserId).get()
+		roomGet.forEach(doc => {
 			let data = {
 				id: doc.id
 			}
-			if(this.currentUserId === data.id) {
-				this.user = data
-			}else{
-				// console.log("success")
-			}
+			this.rooms.push(data)
 		})
 	},
 	data: () => ({
-		currentUserId:'',
 		rooms:[],
 		user:'',
 		users:[],
 		open: false,
 		auth: null
 	}),
-	methods: {
-		async getRooms() {
-			const roomRef = firebase.firestore().collection("rooms")
-			const snapshot = await roomRef.get()
-
-			snapshot.forEach(doc => {
-				let data = {
-					id: doc.id
-				}
-				this.rooms.push(data)
-			})
-		},
-	}
 }
 </script>


### PR DESCRIPTION
### 内容
ログインユーザーとルームの紐付け処理実装。

### 確認事項
- [ ] roomのフィールドの値にあるmembers_idから各メンバーを探索して、ルームの表示が出来ているか
- [ ] アンケート作成からグループ作成まで一連の挙動が動作しているか

### 注意書き
アンケート回収画面で、グループ作成したのち、ルーム画面に遷移しても、作成したグループは作成されない。
→roomのmemberのフィールドの値が、"[""]"になってるので一旦、member_idの値は[""]にしてみて、挙動確認してみてください🙇‍♂️

### 次の作業
とりあえず、friendの値を"[""]"→[""]に直すわ！そこに付随する処理も修正します👈
また、不参加にしたのに次の画面に遷移するのもイシューに追加して、後ほど直す！